### PR TITLE
feat: do not use erc2470 to deploy by default; make it optional instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ cp .env.example .env
 source .env
 ```
 
+2. Deploy EVMAuth contract:
+```sh
+forge script script/DeployEVMAuth.s.sol:DeployEVMAuth --rpc-url "$RPC_URL" --broadcast
+```
+
+### Deploy Contract with Deterministic Address
+
+> ⚠️ **IMPORTANT:** Set the `APP_NAME` and `APP_VERSION` in the `.env` file to something unique.
+>
+> If you attempt to deploy the contract with the same name and version as an existing contract, it will fail because
+> the deployment script uses the [ERC-2470] Singleton Factory, for deterministic addresses.
+
+1. Load environment variables:
+```sh
+source .env
+```
+
 2. Verify [ERC-2470] Singleton Factory is deployed on the target network:
 ```sh
 cast code 0xce0042B868300000d44A59004Da54A005ffdcf9f --rpc-url="$RPC_URL"
@@ -39,12 +56,12 @@ cast code 0xce0042B868300000d44A59004Da54A005ffdcf9f --rpc-url="$RPC_URL"
 
 3. Predict contract address and project ID:
 ```sh
-forge script script/DeployEVMAuth.s.sol:DeployEVMAuth --sig "predictAddress()" --rpc-url "$RPC_URL"
+forge script script/DeployEVMAuthViaERC2470.s.sol:DeployEVMAuth --sig "predictAddress()" --rpc-url "$RPC_URL"
 ```
 
 4. Deploy EVMAuth contract:
 ```sh
-forge script script/DeployEVMAuth.s.sol:DeployEVMAuth --rpc-url "$RPC_URL" --broadcast
+forge script script/DeployEVMAuthViaERC2470.s.sol:DeployEVMAuth --rpc-url "$RPC_URL" --broadcast
 ```
 
 ### Generate ABI & Bytecode

--- a/script/DeployEVMAuth.s.sol
+++ b/script/DeployEVMAuth.s.sol
@@ -28,13 +28,7 @@ contract DeployEVMAuth is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         // Simple direct deployment using the standard CREATE opcode
-        EVMAuth evmAuth = new EVMAuth(
-            NAME,
-            VERSION,
-            URI,
-            DELAY,
-            deployer
-        );
+        EVMAuth evmAuth = new EVMAuth(NAME, VERSION, URI, DELAY, deployer);
 
         address contractAddress = address(evmAuth);
 

--- a/script/DeployEVMAuth.s.sol
+++ b/script/DeployEVMAuth.s.sol
@@ -5,29 +5,12 @@ import "forge-std/Script.sol";
 import "forge-std/console.sol";
 import "../src/EVMAuth.sol";
 
-interface ISingletonFactory {
-    function deploy(bytes memory _initCode, bytes32 _salt) external returns (address payable deployedAddress);
-}
-
 contract DeployEVMAuth is Script {
-    // The canonical address of the Singleton Factory (same on all chains)
-    address public constant SINGLETON_FACTORY = 0xce0042B868300000d44A59004Da54A005ffdcf9f;
-
     // Environment variables for deployment
     string private NAME = vm.envString("APP_NAME");
     string private VERSION = vm.envString("APP_VERSION");
     string private URI = vm.envString("APP_METADATA_URI");
     uint48 private DELAY = 3 days; // 72-hour safety delay for contract ownership transfer
-
-    /**
-     * @dev Generate the constructor arguments for the contract being deployed
-     * @param deployer The address of the deployer
-     * @return The encoded constructor arguments
-     */
-    function _constructorArgs(address deployer) internal view returns (bytes memory) {
-        // Use abi.encode instead of abi.encodePacked for dynamic types
-        return abi.encode(NAME, VERSION, URI, DELAY, deployer);
-    }
 
     /**
      * @dev Generate a unique project ID based on the name and version
@@ -37,55 +20,29 @@ contract DeployEVMAuth is Script {
         return keccak256(abi.encodePacked(NAME, VERSION));
     }
 
-    /**
-     * @dev Generate a salt, to ensure the same contract deploys to the same address across chains
-     * @param args The constructor arguments for the contract being deployed
-     * @return The generated salt
-     */
-    function _salt(bytes memory args) internal view returns (bytes32) {
-        // Use a more predictable salt based on project ID
-        return keccak256(abi.encodePacked(_projectID(), args));
-    }
-
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         address deployer = vm.addr(deployerPrivateKey);
-        bytes memory args = _constructorArgs(deployer);
-        bytes32 salt = _salt(args);
+        bytes32 projectID = _projectID();
 
         vm.startBroadcast(deployerPrivateKey);
 
-        // Create initialization bytecode
-        bytes memory initCode = abi.encodePacked(type(EVMAuth).creationCode, args);
+        // Simple direct deployment using the standard CREATE opcode
+        EVMAuth evmAuth = new EVMAuth(
+            NAME,
+            VERSION,
+            URI,
+            DELAY,
+            deployer
+        );
 
-        // Deploy via Singleton Factory
-        address contractAddress = ISingletonFactory(SINGLETON_FACTORY).deploy(initCode, salt);
+        address contractAddress = address(evmAuth);
 
         vm.stopBroadcast();
 
         // Log deployment information
         console.log("Contract Address: %s", vm.toString(contractAddress));
         console.log("Deployer Address: %s", vm.toString(deployer));
-        console.log("Project ID: %s", vm.toString(_projectID()));
-    }
-
-    /**
-     * @dev Predict the address of the deployed contract using the Singleton Factory
-     * @return The predicted address of the deployed contract
-     */
-    function predictAddress() external view returns (address, bytes32) {
-        address deployer = vm.addr(vm.envUint("PRIVATE_KEY"));
-        bytes memory args = _constructorArgs(deployer);
-        bytes32 salt = _salt(args);
-        bytes32 projectID = _projectID();
-
-        // Create initialization bytecode
-        bytes memory initCode = abi.encodePacked(type(EVMAuth).creationCode, args);
-
-        // Calculate address using CREATE2 formula
-        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), SINGLETON_FACTORY, salt, keccak256(initCode)));
-
-        // Return the predicted contract address
-        return (address(uint160(uint256(hash))), projectID);
+        console.log("Project ID: %s", vm.toString(projectID));
     }
 }

--- a/script/DeployEVMAuthViaERC2470.s.sol
+++ b/script/DeployEVMAuthViaERC2470.s.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import "../src/EVMAuth.sol";
+
+interface ISingletonFactory {
+    function deploy(bytes memory _initCode, bytes32 _salt) external returns (address payable deployedAddress);
+}
+
+contract DeployEVMAuth is Script {
+    // The canonical address of the Singleton Factory (same on all chains)
+    address public constant SINGLETON_FACTORY = 0xce0042B868300000d44A59004Da54A005ffdcf9f;
+
+    // Environment variables for deployment
+    string private NAME = vm.envString("APP_NAME");
+    string private VERSION = vm.envString("APP_VERSION");
+    string private URI = vm.envString("APP_METADATA_URI");
+    uint48 private DELAY = 3 days; // 72-hour safety delay for contract ownership transfer
+
+    /**
+     * @dev Generate the constructor arguments for the contract being deployed
+     * @param deployer The address of the deployer
+     * @return The encoded constructor arguments
+     */
+    function _constructorArgs(address deployer) internal view returns (bytes memory) {
+        // Use abi.encode instead of abi.encodePacked for dynamic types
+        return abi.encode(NAME, VERSION, URI, DELAY, deployer);
+    }
+
+    /**
+     * @dev Generate a unique project ID based on the name and version
+     * @return The generated project ID
+     */
+    function _projectID() internal view returns (bytes32) {
+        return keccak256(abi.encodePacked(NAME, VERSION));
+    }
+
+    /**
+     * @dev Generate a salt, to ensure the same contract deploys to the same address across chains
+     * @param args The constructor arguments for the contract being deployed
+     * @return The generated salt
+     */
+    function _salt(bytes memory args) internal view returns (bytes32) {
+        // Use a more predictable salt based on project ID
+        return keccak256(abi.encodePacked(_projectID(), args));
+    }
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        bytes memory args = _constructorArgs(deployer);
+        bytes32 salt = _salt(args);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Create initialization bytecode
+        bytes memory initCode = abi.encodePacked(type(EVMAuth).creationCode, args);
+
+        // Deploy via Singleton Factory
+        address contractAddress = ISingletonFactory(SINGLETON_FACTORY).deploy(initCode, salt);
+
+        vm.stopBroadcast();
+
+        // Log deployment information
+        console.log("Contract Address: %s", vm.toString(contractAddress));
+        console.log("Deployer Address: %s", vm.toString(deployer));
+        console.log("Project ID: %s", vm.toString(_projectID()));
+    }
+
+    /**
+     * @dev Predict the address of the deployed contract using the Singleton Factory
+     * @return The predicted address of the deployed contract
+     */
+    function predictAddress() external view returns (address, bytes32) {
+        address deployer = vm.addr(vm.envUint("PRIVATE_KEY"));
+        bytes memory args = _constructorArgs(deployer);
+        bytes32 salt = _salt(args);
+        bytes32 projectID = _projectID();
+
+        // Create initialization bytecode
+        bytes memory initCode = abi.encodePacked(type(EVMAuth).creationCode, args);
+
+        // Calculate address using CREATE2 formula
+        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), SINGLETON_FACTORY, salt, keccak256(initCode)));
+
+        // Return the predicted contract address
+        return (address(uint160(uint256(hash))), projectID);
+    }
+}


### PR DESCRIPTION
## Description

This PR removes the [ERC-2470 Singleton Factory](https://eips.ethereum.org/EIPS/eip-2470) logic from `script/DeployEVMAuth.s.sol` (the default script), and instead make it available in a new script called `script/DeployEVMAuthViaERC2470.s.sol`.

Contract deployment instructions in `README.md` have been accordingly.

Fixes #9 

## Type of change

- [x] Documentation update
- [x] Build or dependency update

## How Has This Been Tested?

- [x] Manual tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Additional context:

This change does not affect existing contracts. The address generated using `script/DeployEVMAuthViaERC2470.s.sol` is the same as it was previously when using the default script.