### PR TITLE
chore: fix docs workflow in GH Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,7 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -17,7 +18,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Generate docs
-        run: forge doc --build --include
+        run: forge doc --build
 
       - name: Install and configure mdbook-mermaid
         run: |


### PR DESCRIPTION
Quick fix for the new GitHub Actions workflow that auto-generates the documentation site.