### PR TITLE
chore: install dependencies before building docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
+      - name: Install dependencies
+        run: |
+          forge install foundry-rs/forge-std --no-commit
+          forge install OpenZeppelin/openzeppelin-contracts-upgradeable --no-commit
+          forge install OpenZeppelin/openzeppelin-foundry-upgrades --no-commit
+
       - name: Generate docs
         run: forge doc --build
 


### PR DESCRIPTION
Quick fix to install dependencies in GH Actions workflow before building docs site.