### PR TITLE
chore: remove invalid forge install flags in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          forge install foundry-rs/forge-std --no-commit
-          forge install OpenZeppelin/openzeppelin-contracts-upgradeable --no-commit
-          forge install OpenZeppelin/openzeppelin-foundry-upgrades --no-commit
+          forge install foundry-rs/forge-std
+          forge install OpenZeppelin/openzeppelin-contracts-upgradeable
+          forge install OpenZeppelin/openzeppelin-foundry-upgrades
 
       - name: Generate docs
         run: forge doc --build


### PR DESCRIPTION
Quick fix to remove invalid `--no-commit` flags when calling  `forge install` in the `docs` workflow.