### PR TITLE
chore: do not install lib/forge-std in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          forge install foundry-rs/forge-std
           forge install OpenZeppelin/openzeppelin-contracts-upgradeable
           forge install OpenZeppelin/openzeppelin-foundry-upgrades
 


### PR DESCRIPTION
Quick fix for `docs` workflow—do not install `lib/forge-std`.