### PR TITLE
chore: install mbook and mbook-mermaid to add mermaid support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Generate docs
         run: forge doc --build
 
-      - name: Install and configure mdbook-mermaid
+      - name: Install mdbook and mdbook-mermaid
         run: |
+          cargo install mdbook --version "^0.4"
           cargo install mdbook-mermaid
           mdbook-mermaid install docs/
           


### PR DESCRIPTION
Quick fix to install both `mbook` and `mbook-mermaid`, in order to regenerate docs site with Mermaid Markdown support.