### PR TITLE
chore: remove mdbook-mermaid plugin installation step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,25 +25,6 @@ jobs:
       - name: Generate docs
         run: forge doc --build
 
-      - name: Install mdbook and mdbook-mermaid
-        run: |
-          cargo install mdbook --version "^0.4"
-          cargo install mdbook-mermaid
-          mdbook-mermaid install docs/
-          
-          # Add preprocessor config to generated book.toml
-          cat >> docs/book.toml << 'EOF'
-          
-          [preprocessor.mermaid]
-          command = "mdbook-mermaid"
-          
-          [output.html]
-          additional-js = ["mermaid.min.js", "mermaid-init.js"]
-          EOF
-          
-          # Rebuild with mermaid support
-          cd docs && mdbook build
-
       - name: Setup Pages
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
Remove the step to install the `mdbook-mermaid` plugin altogether. It is failing and may not have even been necessary.

```
   Compiling mdbook-mermaid v0.15.0
    Finished `release` profile [optimized] target(s) in 1m 03s
  Installing /home/runner/.cargo/bin/mdbook-mermaid
   Installed package `mdbook-mermaid v0.15.0` (executable `mdbook-mermaid`)
[2025-09-11T16:52:45Z INFO  mdbook_mermaid] Reading configuration file docs/book.toml
[2025-09-11T16:52:45Z INFO  mdbook_mermaid] Adding preprocessor configuration
[2025-09-11T16:52:45Z INFO  mdbook_mermaid] Adding additional files to configuration
[2025-09-11T16:52:45Z INFO  mdbook_mermaid] Saving changed configuration to docs/book.toml
[2025-09-11T16:52:45Z INFO  mdbook_mermaid] Writing additional files to project directory at docs/
[2025-09-11T16:52:45Z INFO  mdbook_mermaid] Files & configuration for mdbook-mermaid are installed. You can start using it in your book.
[2025-09-11T16:52:45Z INFO  mdbook_mermaid] Add a code block like:
    ```mermaid
    graph TD;
        A-->B;
        A-->C;
        B-->D;
        C-->D;
    ```
Error: -11 16:52:45 [ERROR] (mdbook::utils): Error: Invalid configuration file
Error: -11 16:52:45 [ERROR] (mdbook::utils): 	Caused By: redefinition of table `output.html` for key `output.html` at line 23 column 1
Error: Process completed with exit code 101.
```